### PR TITLE
Fixes publish workflow to use changesets

### DIFF
--- a/.changeset/two-points-provide.md
+++ b/.changeset/two-points-provide.md
@@ -1,0 +1,6 @@
+---
+"hello-world": patch
+"hello-world-target": patch
+---
+
+Fixes to publish workflow to create github release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,8 +78,11 @@ jobs:
       - id: build
         run: pnpm run build
 
-      - id: publish
-        run: pnpm run ci:publish
+      - uses: changesets/action@master
+        with:
+          publish: pnpm run ci:publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@v2.2.2
         with:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,6 @@ importers:
   steps/hello-world:
     specifiers:
       '@changesets/cli': ^2.16.0
-      '@octopusdeploy/hello-world-target': 1.0.0
       '@octopusdeploy/step-api': 1.0.0
       '@octopusdeploy/step-package-cli': 1.0.0
       '@types/jest': ^26.0.22
@@ -49,6 +48,7 @@ importers:
       eslint-plugin-jest: ^24.3.5
       eslint-plugin-prefer-arrow: ^1.2.3
       eslint-plugin-prettier: ^3.4.0
+      hello-world-target: 1.0.0
       jest: ^26.6.3
       jest-cli: ^26.6.3
       jest-expect-message: ^1.0.2
@@ -59,7 +59,7 @@ importers:
       tslib: ^2.3.0
       typescript: ^4.2.3
     dependencies:
-      '@octopusdeploy/hello-world-target': link:../../targets/hello-world-target
+      hello-world-target: link:../../targets/hello-world-target
       tslib: 2.3.1
     devDependencies:
       '@changesets/cli': 2.17.0

--- a/steps/hello-world/CHANGELOG.md
+++ b/steps/hello-world/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @octopusdeploy/hello-world
+# hello-world
 
 ## 1.0.0
 ### Major Changes

--- a/steps/hello-world/package.json
+++ b/steps/hello-world/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@octopusdeploy/hello-world",
+  "name": "hello-world",
   "version": "1.0.0",
   "main": "dist/inputs.js",
   "scripts": {
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "tslib": "^2.3.0",
-    "@octopusdeploy/hello-world-target": "1.0.0"
+    "hello-world-target": "1.0.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.16.0",

--- a/steps/hello-world/src/executor.ts
+++ b/steps/hello-world/src/executor.ts
@@ -1,6 +1,6 @@
 import HelloWorldStepInputsV1 from "./inputs";
 import { StepExecutor } from "@octopusdeploy/step-api";
-import HelloWorldTargetInputs from "@octopusdeploy/hello-world-target";
+import HelloWorldTargetInputs from "hello-world-target";
 
 const HelloWorldStepExecutor: StepExecutor<HelloWorldStepInputsV1, HelloWorldTargetInputs> = async ({ inputs, target, context }) => {
     context.print(target.greetingPrefix + " " + inputs.name);

--- a/targets/hello-world-target/CHANGELOG.md
+++ b/targets/hello-world-target/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @octopusdeploy/hello-world-target
+# hello-world-target
 
 ## 1.0.0
 ### Major Changes

--- a/targets/hello-world-target/package.json
+++ b/targets/hello-world-target/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@octopusdeploy/hello-world-target",
+  "name": "hello-world-target",
   "version": "1.0.0",
   "main": "dist/inputs.js",
   "scripts": {


### PR DESCRIPTION
When the template was created from the migration sample it didn't have github release creation using changesets as part of the publish workflow as there are some tooling challenges with this at the moment.

This PR updates the package names to match the step id and fixes up the publish workflow so that it uses changesets. This should result in github releases getting created successfully on publish.