### PR TITLE
Adds slack notification on nightly build failure

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -162,3 +162,18 @@ jobs:
           publish: npx changeset tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  notify:
+    runs-on: ubuntu-latest
+    name: Slack - Notify on nightly build failure
+    needs: [build, publish_nightly]
+    if: ${{ github.event_name == 'schedule' && failure() }}
+
+    steps:
+      - name: Notify
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -162,6 +162,7 @@ jobs:
           publish: npx changeset tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
   notify:
     runs-on: ubuntu-latest
     name: Slack - Notify on nightly build failure


### PR DESCRIPTION
This PR adds slack notification to the channel referenced in `SLACK_NOTIFICATIONS_CHANNEL` secret if there is a failure in the nightly build.