### PR TITLE
Uses changesets token and pins octo cli version

### DIFF
--- a/.changeset/dry-hounds-dress.md
+++ b/.changeset/dry-hounds-dress.md
@@ -1,0 +1,6 @@
+---
+"hello-world": patch
+"hello-world-target": patch
+---
+
+Uses changesets token and pins octo cli for build

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -84,7 +84,7 @@ jobs:
 
       - uses: OctopusDeploy/install-octopus-cli-action@v1.1.10
         with:
-          version: latest
+          version: 7.4.3663
 
       - name: Add pre-release changeset
         id: add_pre_release_changeset
@@ -148,7 +148,7 @@ jobs:
 
       - uses: OctopusDeploy/install-octopus-cli-action@v1.1.10
         with:
-          version: latest
+          version: 7.4.3663
 
       - name: Publish Release
         # Shift the additional arguments three times - Shift pass the top level ci:publish, past the step-specific "build" invocation, and add them to the step-specific "publishToOctopus" invocation
@@ -162,7 +162,7 @@ jobs:
           publish: npx changeset tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
   notify:
     runs-on: ubuntu-latest
     name: Slack - Notify on nightly build failure

--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false # Fixes issue identified in https://github.com/changesets/action/issues/70
 
       - uses: pnpm/action-setup@v2.0.1
         with:

--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           version: pnpm run ci:version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}


### PR DESCRIPTION
As part of #project-miso-change-control, all repos now require a PR and a green build. This causes an issue for PRs that are created for package versioning by the changesets action, as PRs created using the default `GITHUB_TOKEN` do not trigger checks.

This PR changes the create-versioning-pr workflow to use the org-level `CHANGESETS_GITHUB_TOKEN`. 

It also pins the version of octo cli being used to `7.4.3663` as the newer version `9.0.0` requires a `--gitRef` parameter to be passed when creating releases for versioned controlled projects and the step-package-cli currently doesn't supply this.