### PR TITLE
adding new renovate PR workflow

### DIFF
--- a/.github/workflows/renovate-pull-request-automation.yml
+++ b/.github/workflows/renovate-pull-request-automation.yml
@@ -1,0 +1,26 @@
+name: "Renovate Pull Request Approval"
+
+on:
+  pull_request:
+    branches: [main]
+
+# Increase the access for the GITHUB_TOKEN
+permissions:
+  # This Allows the GITHUB_TOKEN to approve pull requests
+  pull-requests: write
+  # This Allows the GITHUB_TOKEN to auto merge pull requests
+  contents: write
+
+env:
+  PR_URL: ${{github.event.pull_request.html_url}}
+  # By default, GitHub Actions workflows triggered by renovate get a GITHUB_TOKEN with read-only permissions.
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+  approve_renovate_pull_requests:
+    runs-on: ubuntu-latest
+    name: Approve renovate pull request
+    if: ${{ (github.actor == 'Octobob') && (contains(github.head_ref, 'renovate')) }}
+    steps:
+      - name: Approve a renovate created PR
+        run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
Dependencies within this repo are automatically updated using renovate. This involves creating a PR with a dependency update which can then be auto-merged by renovate if all it's checks pass and it is performing a patch or digest level change.

#project-miso-change-control has introduced a PRGB requirement for all changes to our software. In the context of renovate we already have a PR with builds but renovate can no longer auto-merge without an approval on the PR.

This PR introduces a workflow that will auto-approve any PR that is opened by renovate. PRs that are not patch/digest changes should still not be auto-merged by renovate and will need manual review/merging.