### PR TITLE
Updating workflows actions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.9.5
 
       - name: setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: "14.*"
           cache: "pnpm"
@@ -59,16 +59,16 @@ jobs:
     if: ${{ github.event_name == 'schedule' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.9.5
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: "14.*"
           cache: "pnpm"
@@ -82,13 +82,13 @@ jobs:
       - name: Build
         run: pnpm run ci:build
 
-      - uses: OctopusDeploy/install-octopus-cli-action@v1.1.10
+      - uses: OctopusDeploy/install-octopus-cli-action@v1.2.1
         with:
           version: 7.4.3663
 
       - name: Add pre-release changeset
         id: add_pre_release_changeset
-        uses: OctopusDeploy/util-actions/add-changeset@add-changeset.0.1.1
+        uses: OctopusDeploy/util-actions/add-changeset@add-changeset.0.2.0
         with:
           type: patch
           summary: Changeset added for pre-release versioning
@@ -97,20 +97,12 @@ jobs:
             **/node_modules/**/*
             **/__tests__/**/*
 
-      - name: Get branch names
-        id: branch_names
-        uses: tj-actions/branch-names@v4.5
-
       - name: Replace invalid branch characters
-        uses: OctopusDeploy/util-actions/find-and-replace-all@find-and-replace-all.0.1.0
-        id: extract_branch
-        with:
-          source: ${{ steps.branch_names.outputs.current_branch }}
-          searchString: "/"
-          replace: "-"
+        uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
+        id: branch_names
 
       - name: Version packages
-        run: pnpm changeset version --snapshot ${{ steps.extract_branch.outputs.value }}
+        run: pnpm changeset version --snapshot ${{ steps.branch_names.outputs.branch_name }}
 
       - name: Publish
         run: "pnpm run ci:publish -s ${{ secrets.OCTOPUS_URL }} -k ${{ secrets.OCTOPUS_API_KEY }} --space ${{ secrets.OCTOPUS_SPACE }} --project ${{ secrets.OCTOPUS_PROJECT }} --deployTo Nightly --channel Nightly"
@@ -122,16 +114,16 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'schedule' && startsWith(github.event.commits[0].message, 'Version Packages') }}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.9.5
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: "14.*"
           cache: "pnpm"
@@ -145,7 +137,7 @@ jobs:
       - name: Build
         run: pnpm run ci:build
 
-      - uses: OctopusDeploy/install-octopus-cli-action@v1.1.10
+      - uses: OctopusDeploy/install-octopus-cli-action@v1.2.1
         with:
           version: 7.4.3663
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm run ci:test
 
       - name: Upload test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v1.6.0
         if: success() || failure()
         with:
           name: Jest tests
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Notify
-        uses: voxmedia/github-action-slack-notify-build@v1
+        uses: voxmedia/github-action-slack-notify-build@v1.6.0
         with:
           channel: ${{ secrets.SLACK_NOTIFICATIONS_CHANNEL }}
           status: FAILED

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -97,7 +97,7 @@ jobs:
             **/node_modules/**/*
             **/__tests__/**/*
 
-      - name: Replace invalid branch characters
+      - name: Get branch names
         uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
         id: branch_names
 

--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -14,17 +14,17 @@ jobs:
     if: ${{ !startsWith(github.event.commits[0].message, 'Version Packages') }}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
           persist-credentials: false # Fixes issue identified in https://github.com/changesets/action/issues/70
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.9.5
 
       - name: setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: "14.*"
           cache: "pnpm"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   
   workflow_dispatch:
     inputs:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -2,7 +2,7 @@ name: Renovate
 on:
   schedule:
     - cron: "0 0 * * *"
-  
+
   workflow_dispatch:
     inputs:
       dryRun:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,26 +1,33 @@
 name: Renovate
 on:
   schedule:
-    - cron: "0 0 * * *"
-
+    - cron: '0 0 * * *'
+  
   workflow_dispatch:
+    inputs:
+      dryRun:
+        type: boolean
+        required: false
+        default: false
+        description: Dry run (don't create PRs)
 
 jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v3.3.0
 
-      # Note: Renovate runs within it's own docker container and doesn't
+      # Note: Renovate runs within it's own docker container and doesn't 
       # know really anything about which version of tooling are in use e.g. pnpm
       # it just uses the latest version. This could potentially cause issues if
       # a new major version of pnpm gets released, so we have a constraint in
-      # the renovate-config.js file to restrict it to use v6 to align with us.
+      # the renovate-config.js file to restrict it to use a specific version of pnpm to align with us.
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v29.36.2
+        uses: renovatebot/github-action@v34.104.0
         with:
           configurationFile: renovate-config.js
           token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
         env:
           LOG_LEVEL: debug
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun && 'full' || null }}


### PR DESCRIPTION
This PR is updating several GitHub action dependencies for workflows in this repo to address the following.

1. GitHub actions have a potential script vulnerability attack using a poisoned branch name, for example test");env;# this will expose all environment variables in the workflow run. The action tj-actions/branch-names was identified as being vulnerable to this attack vector as it uses scripts that inject a branch name into them directly in some scenarios.

2. A number of deprecation warnings have appeared in our GitHub action workflows over the recent few months that need addressing from node 12 as this is being [removed in September 2023](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). and the way actions are outputting data with [the set-output and save-state commands are deprecated and will be removed in June 2023](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

This PR is addressing these in the following ways:

1. Replacing the usage tj-actions/branch-names with the new OctopusDeploy/util-actions/current-branch-name action, which is not vulnerable to this attack vector.

2. Updating all dependencies that use node 12 to a version that is still supported by later versions of node and also updating all dependencies to versions that don't use the deprecated commands.

Floating versions (e.g. action@v2) have also been converted to pinned versions to match our usage elsewhere.

Shortcut: 
[sc-9312] 
[sc-36960]
[sc-36964]