### PR TITLE
Updating changesets/action to remove warnings

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -147,7 +147,7 @@ jobs:
           echo 'pnpm run ci:publish -s ${{ secrets.OCTOPUS_URL }} -k ${{ secrets.OCTOPUS_API_KEY }} --space ${{ secrets.OCTOPUS_SPACE }} --project ${{ secrets.OCTOPUS_PROJECT }} --deployTo PreProd --channel Release'
 
       - name: Tag repo
-        uses: changesets/action@v1.3.0
+        uses: changesets/action@v1.4.1
         with:
           publish: npx changeset tag
         env:

--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -35,7 +35,7 @@ jobs:
       # run it here after the cache
       - run: pnpm install
 
-      - uses: changesets/action@v1.3.0
+      - uses: changesets/action@v1.4.1
         with:
           version: pnpm run ci:version
         env:


### PR DESCRIPTION
This is a follow on PR from OctopusDeploy/step-package-template#106 to update the action changesets/action to v1.4.1 that was missed and is still producing warnings.