### PR TITLE
Updating step and target to have @octopusdeploy/ prefix.

### DIFF
--- a/.changeset/dry-hounds-dress.md
+++ b/.changeset/dry-hounds-dress.md
@@ -1,6 +1,6 @@
 ---
-"hello-world": patch
-"hello-world-target": patch
+"@octopusdeploy/hello-world": patch
+"@octopusdeploy/hello-world-target": patch
 ---
 
 Uses changesets token and pins octo cli for build

--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ They implement a common [Step API](https://github.com/OctopusDeploy/step-api/blo
 
 Adding a new target involves creating the following files under the `targets/<target-name>-target` directory. In the case of this sample step package, we'll create them under `targets/hello-world-target`:
 
-> Note: The package name in the package.json for the target template contains `@octopusdeploy/` for security reasons. Please ensure you remove this when renaming your target.
-
 * `src`
   * `metadata.json`
   * `inputs.ts`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Step packages are:
 
 This sample template provides a starting point for anyone looking to create a new step package. The code in this repository defines a _Hello World_ target and step demonstrating a minimal step package implementation.
 
-Building this template will result in two step packages being produced: 
+Building this template will result in two-step packages being produced: 
 - `hello-world-target.x.y.z.zip` 
 - `hello-world-upload.x.y.z.zip`
 
@@ -84,6 +84,8 @@ They implement a common [Step API](https://github.com/OctopusDeploy/step-api/blo
 ### Adding a new target
 
 Adding a new target involves creating the following files under the `targets/<target-name>-target` directory. In the case of this sample step package, we'll create them under `targets/hello-world-target`:
+
+> Note: The package name in the package.json for the target template contains `@octopusdeploy/` for security reasons. Please ensure you remove this when renaming your target.
 
 * `src`
   * `metadata.json`
@@ -164,6 +166,8 @@ Adding a new step closely resembles adding a new deployment target. New files fo
 
 The key differences for steps are outlined below. Anything not outlined is assumed to be the same as defined for adding a new target.
 
+> Note: The package name in the package.json for the step template contains `@octopusdeploy/` for security reasons. Please ensure you remove this when renaming your step.
+
 ### `metadata.json`
 
 Step metadata differs slightly from target metadata.
@@ -189,6 +193,10 @@ The step form displayed by the Octopus web UI is defined much the same as it was
 Here we define the initial value of the `name` input to be a blank string, and build the form with a single `text` input:
 
 https://github.com/OctopusDeploy/step-package-template/blob/eca604f5111c817a082855a9a53002888748e69b/steps/hello-world/src/ui.ts
+
+## Target-less step packages
+
+Your step package may not require a target which means it can be removed. It's important to remember to also remove all references to the target package in your step. eg: remove references to `@octopusdeploy/hello-world-target` in [executor.ts](https://github.com/OctopusDeploy/step-package-template/blob/main/steps/hello-world/src/executor.ts) and [package.json](https://github.com/OctopusDeploy/step-package-template/blob/main/steps/hello-world/package.json)
 
 ## Building the step package
 
@@ -218,9 +226,9 @@ In order to add a change set, run `npx changeset add` which will:
 
 These details will automatically be captured in a markdown file under the `.changesets` folder within your PR.
 
-Once your PR is merged, the build will use the [Changesets Github Action](https://github.com/changesets/action) to create a separate _Version Packages_ PR which includes the merged release notes within the appropriate `CHANGELOG.md` files, and applied version bumps within the appropriate `package.json` files, which you will need to review.
+Once your PR is merged, the build will use the [Changesets GitHub Action](https://github.com/changesets/action) to create a separate _Version Packages_ PR which includes the merged release notes within the appropriate `CHANGELOG.md` files, and applied version bumps within the appropriate `package.json` files, which you will need to review.
 
-Upon merging the _Version Packages_ PR, the repository will be tagged with the new version, and a Github Release will be created for each changed step package.
+Upon merging the _Version Packages_ PR, the repository will be tagged with the new version, and a GitHub Release will be created for each changed step package.
 
 To access the newly-versioned package, you can retrieve it from the build artifacts produced after the `Version Packages` PR is merged.
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,11 @@ Step packages are:
 
 This sample template provides a starting point for anyone looking to create a new step package. The code in this repository defines a _Hello World_ target and step demonstrating a minimal step package implementation.
 
-Building this template will result in two-step packages being produced: 
+Building this template will result in two step packages being produced: 
 - `hello-world-target.x.y.z.zip` 
 - `hello-world-upload.x.y.z.zip`
-
+ 
 Any step packages built from this template will be compatible with Octopus Server v2021.3 and newer.
-
-> Note: You don't have to use the template, but if you don't you will need to set everything up manually, and currently we have no guide on how to do this.
 
 To learn more about step packages, consult the [step package documentation](https://github.com/OctopusDeploy/step-api/blob/main/docs/StepPackages.md).
 
@@ -26,9 +24,11 @@ To learn more about step packages, consult the [step package documentation](http
 
 1. Click the "Use this template" button above to create a new GitHub repository using this template.
 2. Clone the repository to your machine.
-3. Use the steps listed in the [Building the step package](#building-the-step-package) section below to build and deploy the step package locally.
-4. Follow the instructions in the [Releasing the step package](#releasing-the-step-package) section below to build and release the step package via GitHub Actions.
+3. Use the steps listed in the [Building the step package](#building-the-step-package) section below to build and deploy the step package locally. 
+4. Follow the instructions in the [Releasing the step package](#releasing-the-step-package) section below to build and release the step package via GitHub Actions. 
 5. Update `renovate-config.js` to point to your newly created repository. See [Dependency Management](#dependency-management) for more information.
+
+> Note: Please review the names of the packages in your repository before publishing to ensure they are named appropriately.
 
 ## Project structure
 
@@ -165,8 +165,6 @@ https://github.com/OctopusDeploy/step-package-template/blob/eca604f5111c817a0828
 Adding a new step closely resembles adding a new deployment target. New files for the step are added under `steps/<step-name>/src`. The same files are required, and the same conventions are followed.
 
 The key differences for steps are outlined below. Anything not outlined is assumed to be the same as defined for adding a new target.
-
-> Note: The package name in the package.json for the step template contains `@octopusdeploy/` for security reasons. Please ensure you remove this when renaming your step.
 
 ### `metadata.json`
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ importers:
   steps/hello-world:
     specifiers:
       '@changesets/cli': 2.18.1
+      '@octopusdeploy/hello-world-target': 1.0.2
       '@octopusdeploy/step-api': 1.4.1
       '@octopusdeploy/step-package-cli': 1.8.2
       '@types/jest': 26.0.24
@@ -52,7 +53,6 @@ importers:
       eslint-plugin-jest: 24.7.0
       eslint-plugin-prefer-arrow: 1.2.3
       eslint-plugin-prettier: 3.4.1
-      hello-world-target: 1.0.2
       jest: 26.6.3
       jest-cli: 26.6.3
       jest-expect-message: 1.1.3
@@ -64,7 +64,7 @@ importers:
       tslib: 2.3.1
       typescript: 4.6.4
     dependencies:
-      hello-world-target: link:../../targets/hello-world-target
+      '@octopusdeploy/hello-world-target': link:../../targets/hello-world-target
       tslib: 2.3.1
     devDependencies:
       '@changesets/cli': 2.18.1

--- a/steps/hello-world/CHANGELOG.md
+++ b/steps/hello-world/CHANGELOG.md
@@ -1,4 +1,4 @@
-# hello-world
+# @octopusdeploy/hello-world
 
 ## 1.0.2
 

--- a/steps/hello-world/package.json
+++ b/steps/hello-world/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world",
+  "name": "@octopusdeploy/hello-world",
   "version": "1.0.2",
   "main": "dist/inputs.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "titleTemplate": "{title}"
   },
   "dependencies": {
-    "hello-world-target": "1.0.2",
+    "@octopusdeploy/hello-world-target": "1.0.2",
     "tslib": "2.3.1"
   },
   "devDependencies": {

--- a/steps/hello-world/src/executor.ts
+++ b/steps/hello-world/src/executor.ts
@@ -1,6 +1,6 @@
 import HelloWorldStepInputsV1 from "./inputs";
 import { StepExecutor } from "@octopusdeploy/step-api";
-import HelloWorldTargetInputs from "hello-world-target";
+import HelloWorldTargetInputs from "@octopusdeploy/hello-world-target";
 
 const HelloWorldStepExecutor: StepExecutor<HelloWorldStepInputsV1, HelloWorldTargetInputs> = async ({ inputs, target, context }) => {
     context.print(target.greetingPrefix + " " + inputs.name);

--- a/targets/hello-world-target/CHANGELOG.md
+++ b/targets/hello-world-target/CHANGELOG.md
@@ -1,4 +1,4 @@
-# hello-world-target
+# @octopusdeploy/hello-world-target
 
 ## 1.0.2
 

--- a/targets/hello-world-target/package.json
+++ b/targets/hello-world-target/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-world-target",
+  "name": "@octopusdeploy/hello-world-target",
   "version": "1.0.2",
   "main": "dist/inputs.js",
   "scripts": {


### PR DESCRIPTION
A security researcher squatted on `hello-world-target` package which exploits a vulnerability in this template as the template references that package. I've updated our step and targets to include the `@octopusdeploy/` prefix so that this can not happen in the future.